### PR TITLE
Initialize sigset in asan_interceptors

### DIFF
--- a/compiler-rt/lib/asan/asan_interceptors.cpp
+++ b/compiler-rt/lib/asan/asan_interceptors.cpp
@@ -251,7 +251,7 @@ INTERCEPTOR(int, pthread_create, void *thread, void *attr,
 
   u32 current_tid = GetCurrentTidOrInvalid();
 
-  __sanitizer_sigset_t sigset;
+  __sanitizer_sigset_t sigset = {};
 #    if SANITIZER_FREEBSD || SANITIZER_LINUX || SANITIZER_NETBSD || \
         SANITIZER_SOLARIS
   ScopedBlockSignals block(&sigset);


### PR DESCRIPTION
When compiling for Darwin, sigset is not initialized.  
When -Werror,-Wuninitialized-const-reference are enabled we see the error:
asan_interceptors.cpp:260:38: error: variable 'sigset' is uninitialized when passed as a const reference argument here [-Werror,-Wuninitialized-const-reference] 

This fixes the error.