### PR TITLE
[lld][ELF] Fix gc-sections-print.s failure in read-only directories

### DIFF
--- a/lld/test/ELF/gc-sections-print.s
+++ b/lld/test/ELF/gc-sections-print.s
@@ -2,7 +2,7 @@
 # RUN: llvm-mc -filetype=obj -triple=x86_64-unknown-linux %s -o %t
 # RUN: ld.lld %t --gc-sections --print-gc-sections -o %t2 2>&1 | FileCheck -check-prefix=PRINT %s
 # RUN: ld.lld %t --gc-sections --print-gc-sections=- -o %t2 2>&1 | FileCheck -check-prefix=PRINT %s
-# RUN: ld.lld %t --gc-sections --print-gc-sections=%t.txt
+# RUN: ld.lld %t --gc-sections --print-gc-sections=%t.txt -o %t2
 # RUN: FileCheck --check-prefix=PRINT %s --input-file=%t.txt
 
 # PRINT:      removing unused section {{.*}}:(.text.x)


### PR DESCRIPTION
If ld.lld is invoked without the `-o` option, it defaults to writing its output to `a.out` in the current directory. This can cause 'Permission denied' errors if a test is executed in a directory without write permissions, as can happen in some build environments.

Add `-o %t2` to this command, consistent with other commands in the same test file, to prevent this failure by ensuring ld.lld writes to a temporary file instead of `a.out`.